### PR TITLE
Raise the documented MOS floor to 2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently it is limited to reading and writing files up to 248KB long with up to
 The editor can work in any Agon supported resolution and will use whatever color scheme you've configured
 your Agon.
 
-`NOTE: VDP 1.04 or above is required (since v0.13.0), and MOS 2.2.0 or above.`
+`NOTE: VDP 1.04 or above is required (since v0.13.0), and MOS 2.2.3 or above.`
 
 # Installation
 
@@ -34,7 +34,11 @@ PC:040046
 MOS treats files in `/mos` as *moslets* and loads them at `0x0B0000`, whereas AED is now linked to
 run from `0x040000`. It cannot be built as a moslet either: the moslet area is 64KB and AED needs
 about 272KB for its buffers. `/bin` is loaded at `0x040000`, which is why the editor lives there
-now. MOS has searched `/bin` since version 2.2.0, hence the version requirement above.
+now.
+
+MOS has searched `/bin` since version 2.2.0, so 2.2 is the lowest usable minor release.
+The supported floor is the **last point release** of that line, 2.2.3 — if you are on
+2.2.x, be on 2.2.3.
 
 # Running the editor.
 If you run it just as `aed` it will start the editor using `/aed.txt` as its backing file. If the file can't be created,


### PR DESCRIPTION
Documentation-only: raises the stated MOS floor from 2.2.0 to **2.2.3**.

## Why

The `/bin` command lookup AED depends on arrives in MOS 2.2.0, so 2.2 is the lowest *usable* minor release. But the supported floor should be the **last point release** of that line, not its first — 2.2.0 through 2.2.3 all shipped within three days (30 Mar – 1 Apr 2024), so there is no reason to carry the earliest of them.

## Verified on the new floor

Ran the same interactive checks on **both ends of the supported range**:

| Check | MOS 3.0.2 / VDP 2.16.0 | MOS 2.2.3 / VDP 1.04 |
|---|---|---|
| CTRL+RIGHT over a 160-char run | `2,164`, line scrolled | `2,164`, identical |
| End / Home on a 167-char line | `2,168` / `2,1` | `2,168` / `2,1` |
| Up then Down | `2,1` | `2,1` |
| Return / BackSpace-merge / CTRL+D | `2501,1` / `2500,6` / `2500,1` | `3,1` / `2,6` / `2,1` |

## Gotcha worth recording

**MOS 2.2.x cannot mount the emulator's host-directory SD emulation.** It boots to `SD card failure` on any VDP, while 2.3.3 and 3.0.2 mount the same directory fine. Testing the floor needs a raw image:

```
./fab-agon-emulator --firmware quark --mos <MOS 2.2.3 MOS.bin> --sdcard-img sd.img
```

That pairing — VDP 1.04 with MOS 2.2.3 — is the true oldest supported combination, rather than whichever MOS ships with the quark firmware (1.04, which is below the floor and correctly reports `Invalid command`).

No code changes.
