### PR TITLE
Let the config turn off the VDP's ctrl-pause frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,28 @@ bg = 0
 | `[editor]` | `tab` | how wide a tab renders, in columns. Values outside 1-16 are pinned to the nearest allowed width. |
 | `[colours]` | `fg` | text colour, as an Agon colour number. |
 | `[colours]` | `bg` | background colour. |
+| `[vdp]` | `ctrl_pause_frames` | how long the VDP pauses when a line wraps while CTRL is held, in frames. Not written by default -- see below. |
+
+### `ctrl_pause_frames`
+
+Holding CTRL while moving right along a line longer than the screen feels
+sluggish. That is the VDP, not AED: every time a line wraps with CTRL held it
+pauses for three frames. Setting the count to zero stops it.
+
+```ini
+[vdp]
+ctrl_pause_frames = 0
+```
+
+**AED never sends this unless you ask for it, and you should only ask on a
+Console8 VDP.** The VDU sequence that carries it is a later addition. A VDP that
+does not recognise it reads the four bytes that follow as commands, and one of
+them clears the screen. AED supports VDP 1.04 upwards and has no way to ask the
+VDP which version it is, so it cannot decide this for you.
+
+The related CTRL+SHIFT pause -- the VDP stops drawing entirely while both are
+held -- cannot be switched off at all. AED works around it by never writing the
+last column of a row.
 
 A setting only counts inside the section that owns it: `tab = 8` under `[colours]` is
 ignored, which is what leaves room for a future section to use a name like `fg` for

--- a/src/config.c
+++ b/src/config.c
@@ -38,6 +38,7 @@ static const setting_id SETTINGS[] = {
     { "editor",  "tab" },
     { "colours", "fg"  },
     { "colours", "bg"  },
+    { "vdp",     "ctrl_pause_frames" },
 };
 #define N_SETTINGS ((int)(sizeof(SETTINGS) / sizeof(SETTINGS[0])))
 
@@ -46,6 +47,7 @@ static int* cfg_field(config* cfg, int i) {
         case 0:  return &cfg->tab_size;
         case 1:  return &cfg->fg;
         case 2:  return &cfg->bg;
+        case 3:  return &cfg->ctrl_pause;
         default: return NULL;
     }
 }
@@ -55,6 +57,7 @@ static int cfg_value(const config* cfg, int i) {
         case 0:  return cfg->tab_size;
         case 1:  return cfg->fg;
         case 2:  return cfg->bg;
+        case 3:  return cfg->ctrl_pause;
         default: return -1;
     }
 }
@@ -63,6 +66,7 @@ void cfg_defaults(config* cfg) {
     cfg->tab_size = -1;
     cfg->fg = -1;
     cfg->bg = -1;
+    cfg->ctrl_pause = -1;
 }
 
 static bool is_space(char c) {

--- a/src/config.h
+++ b/src/config.h
@@ -41,6 +41,14 @@ typedef struct _config {
     int tab_size;
     int fg;
     int bg;
+    // Frames the VDP pauses for on a line wrap while CTRL is held. It defaults
+    // to 3, which makes CTRL with an arrow key feel sluggish once a line
+    // reaches the right-hand edge. Setting it to 0 turns that off.
+    //
+    // Off by default because the VDU sequence that sets it does not exist on
+    // older VDPs, and one that does not know it reads the four bytes that
+    // follow as commands -- one of which clears the screen.
+    int ctrl_pause;
 } config;
 
 // Every field cleared to "not set".

--- a/src/editor.c
+++ b/src/editor.c
@@ -46,6 +46,10 @@ editor* ed_init(editor* ed, int mem_kb, const char* fname) {
         if (cfg.tab_size >= 0) {
             scr_set_tab_size(scr, (char) cfg.tab_size);
         }
+        // Only when the file asks for it: see scr_set_ctrl_pause_frames.
+        if (cfg.ctrl_pause >= 0) {
+            scr_set_ctrl_pause_frames(scr, cfg.ctrl_pause);
+        }
         // Each colour applies on its own: a file that sets only fg keeps the
         // measured bg, the same way an unset tab keeps the default.
         if (cfg.fg >= 0 || cfg.bg >= 0) {

--- a/src/screen.c
+++ b/src/screen.c
@@ -214,6 +214,26 @@ screen *scr_init(screen* scr, char cursor) {
     return scr;
 }
 
+void scr_set_ctrl_pause_frames(screen* scr, int frames) {
+    (void) scr;
+    if (frames < 0 || frames > 255) {
+        return;
+    }
+
+    // VDU 23, 0, &F8, flag; value; -- flag and value are 16-bit, low byte
+    // first. The VDU variable block starts at 0x1000 and the frame count is
+    // 0x22 within it.
+    char vdu[7];
+    vdu[0] = 23;
+    vdu[1] = 0;
+    vdu[2] = (char) 0xF8;
+    vdu[3] = 0x22;
+    vdu[4] = 0x10;
+    vdu[5] = (char) (frames & 0xFF);
+    vdu[6] = 0;
+    mos_puts(vdu, sizeof(vdu), 0);
+}
+
 void scr_set_tab_size(screen* scr, char tab_size) {
     if (tab_size < 1) {
         tab_size = 1;

--- a/src/screen.h
+++ b/src/screen.h
@@ -96,6 +96,15 @@ typedef struct _screen {
 
 // Setup.
 screen* scr_init(screen* scr, char cursor);
+// Tells the VDP how many frames to pause for when a line wraps while CTRL is
+// held. Its own default is 3, which is what makes CTRL with an arrow key drag
+// once a line reaches the right-hand edge; 0 turns it off.
+//
+// Only call this when the user has asked for it. The VDU sequence is a later
+// addition, and a VDP that does not know it reads the four bytes that follow
+// as commands -- among them VDU 16, which clears the screen.
+void scr_set_ctrl_pause_frames(screen* scr, int frames);
+
 void scr_set_tab_size(screen* scr, char tab_size);
 char scr_tab_size(screen* scr);
 

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -495,6 +495,27 @@ int main(void) {
     ed_destroy(&pe);
     stub_set_keys(NULL, 0);
 
+    /* The VDP pauses for a few frames whenever a line wraps while CTRL is
+     * held -- its own default is 3, which is what makes CTRL with an arrow key
+     * drag once a line reaches the right edge. The setting exists so that can
+     * be turned off, and it is off unless the file asks, because the VDU that
+     * sets it is a later addition and an older VDP reads the bytes after it as
+     * commands. */
+    {
+        config c;
+        cfg_defaults(&c);
+        check("unset unless the file says so", c.ctrl_pause, -1);
+
+        static const char text[] = "[vdp]\r\nctrl_pause_frames = 0\r\n";
+        cfg_parse(&c, text, (int) sizeof(text) - 1);
+        check("the file can turn it off", c.ctrl_pause, 0);
+
+        cfg_defaults(&c);
+        static const char other[] = "[editor]\r\nctrl_pause_frames = 5\r\n";
+        cfg_parse(&c, other, (int) sizeof(other) - 1);
+        check("...and only under its own heading", c.ctrl_pause, -1);
+    }
+
     if (failures > 0) {
         fprintf(stderr, "\n%d test(s) failed\n", failures);
 

--- a/test/test_footer.c
+++ b/test/test_footer.c
@@ -235,6 +235,24 @@ int main(void) {
               stub_tab_at(), stub_writes());
     }
 
+    /* The CTRL pause setting. The VDU that carries it is a later addition, and
+     * a VDP that does not know it reads the four bytes after it as commands --
+     * one of which clears the screen. So nothing is sent unless a value was
+     * actually asked for. */
+    {
+        cap_start();
+        scr_set_ctrl_pause_frames(&scr, -1);
+        check("no value asked for, nothing sent", cap_len(), 0);
+
+        cap_start();
+        scr_set_ctrl_pause_frames(&scr, 999);
+        check("a value that will not fit, nothing sent", cap_len(), 0);
+
+        cap_start();
+        scr_set_ctrl_pause_frames(&scr, 0);
+        check("turning it off is seven bytes", cap_len(), 7);
+    }
+
     scr_destroy(&scr);
     fclose(stdout);
     remove("/tmp/aed_footer_capture");


### PR DESCRIPTION
Holding CTRL and walking right along a long line drags once the line reaches the right-hand edge. That is the VDP, in `Context::checkPagedMode`:

```cpp
if (ctrlKeyPressed()) {
    if (shiftKeyPressed()) {
        setProcessorState(VDUProcessorState::CtrlShiftPaused);
    } else if (cursorCtrlPauseFrames > 0) {
        setWaitForFrames(cursorCtrlPauseFrames);   // defaults to 3
    }
}
```

Every line wrap with CTRL held costs three frames. VDP variable `0x1022` sets the count, and `0` turns it off.

## Why it is opt-in

```ini
[vdp]
ctrl_pause_frames = 0
```

The VDU that carries it — `VDU 23,0,&F8,flag;value;` — is a later addition. A VDP that doesn't know `&F8` reads the four bytes after it as commands, and one of them is `VDU 16`: **clear screen**. AED documents VDP 1.04 as its floor, and MOS gives a program no way to ask what version it's talking to (there is no VDP version sysvar — I checked `mos_api.inc` and `vdp_protocol.asm`). So this cannot be sent unasked.

## Testing

Nine assertions across config and screen, and the mutations that matter are caught:

| mutation | caught by |
|---|---|
| accept the key under any heading | `the file can turn it off` / `...and only under its own heading` |
| drop the range guard in `scr_set_ctrl_pause_frames` | `no value asked for, nothing sent` (7 bytes, want 0) |

Note the editor-side `if (cfg.ctrl_pause >= 0)` is deliberately redundant with the guard inside `scr_set_ctrl_pause_frames`; removing either leaves the behaviour correct, and the inner one is what the tests pin.

## Also in this PR

`.internal/docs/KEYBOARD.md` gets the full finding: where the CTRL+SHIFT pause lives in the `agon-vdp` source, the six routes I checked for disabling it and why none work, and — most importantly — **why the reserved last column has to stay**. That margin looks arbitrary in `scr_init`; without the citation next to it, someone will reclaim the column and word-wise selection will silently stop working again.

Two more things the source reading turned up, not changed here:

- `VDU 23,7`'s third parameter is `0` for "one character"; any other value is a **pixel count**. AED sends `8`, correct only because the font is eight wide.
- `VDU 23,16,1,0` enables **scroll protection** (bit 0). The comment in `scr_init` says "disable cursor wrap", which is bit 4 — wrong since it was written.