### PR TITLE
Name the versions behind the xHold decision

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -207,10 +207,21 @@ screen *scr_init(screen* scr, char cursor) {
     // It cannot be switched off. Paged mode does not gate it, VDP variable
     // 0x1022 covers only the CTRL-alone branch, kbEnabled is never cleared,
     // !textCursorActive() means VDU 5, and scrollProtect guards only the
-    // post-string newline. cursorBehaviour.xHold (bit 5) would skip the block
-    // outright, but a VDP that does not implement it wraps and, on the bottom
-    // row, scrolls the screen -- and MOS offers no way to ask the VDP its
-    // version. Not writing the column at all is what works on every VDP.
+    // post-string newline.
+    //
+    // cursorBehaviour.xHold (bit 5) would skip the block outright, and it is
+    // old enough to rely on where the pause exists at all: the pause arrived in
+    // VDP 2.14.0, xHold has worked since Console8 VDP 2.7.0. Note "worked" --
+    // the Quark 1.04 documentation claims bits 4 and 5, but that firmware never
+    // implemented them and the cursor always moved right, so on the floor this
+    // editor supports, setting bit 5 is a silent no-op.
+    //
+    // That is what rules it out. There is no way to send it only to the VDPs
+    // that honour it: MOS cannot report the VDP version, an unsupported VDP
+    // variable "will not be stored, and cannot be read", and the read path
+    // needs 2.12.0 itself, so probing means a serial round trip with a timeout.
+    // Sent unconditionally to an older VDP the bracket does nothing and the
+    // last-column write wraps. Not writing the column works on every VDP.
     //
     // The cost is one column of width. It is a deliberate right margin rather
     // than a lost column, and it is why cols_ is the usable width everywhere


### PR DESCRIPTION
Follow-up to #80, which ruled out `cursorBehaviour.xHold` as a way to reclaim
the last column. The reasoning there was half right and worth correcting while
the trace is fresh.

From agon-docs:

| | first real support |
|---|---|
| `xHold` (bit 5) | Console8 VDP 2.7.0 |
| CTRL+SHIFT pause | VDP 2.14.0 |

The ranges do not overlap. Every VDP that can exhibit the pause honours xHold,
and every VDP that ignores xHold predates the pause. So "a VDP without bit 5
wraps and scrolls the screen" is a real hazard but not the *pause* hazard, and
#80 treated them as one risk.

What actually rules xHold out is narrower, and is the half #80 got right: it
cannot be sent selectively. MOS cannot report the VDP version, an unsupported
VDP variable "will not be stored, and cannot be read" (VDP-Variables.md), and
the variable read path needs 2.12.0 itself -- so probing would mean a serial
round trip with a timeout, which this editor has no machinery for. Sent
unconditionally to an older VDP the bracket is inert and the last-column write
wraps anyway.

The comment also now records the trap in bit 5, which is the part worth having
written down:

> Whilst the Quark documentation claims that bits 4 and 5 are supported in the
> Quark VDP 1.04 release, they were not actually supported in the VDP firmware.
> The cursor would always move right after a character was printed.

1.04 is this editor's documented floor. Bit 5 there is a silent no-op, and the
Quark documentation on its own says the opposite.

Comment only, no behaviour change; suite exits 0.