### PR TITLE
Scroll by the real cell size, not a hardcoded 8

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -228,6 +228,21 @@ screen *scr_init(screen* scr, char cursor) {
     // else in this file.
     scr->cols_ = getsysvar_scrCols() - 1;
     scr->colors_ = getsysvar_scrColours();
+
+    // Cell size for the VDU 23,7 movement byte, derived rather than assumed.
+    // Every stock Agon mode uses the 8x8 system font, so this is 8 today; a
+    // font loaded through the VDP's font API before AED starts would not be,
+    // and a scroll of the wrong distance tears the text area. Guarded because
+    // emitting 0 here would mean "no movement" on an old VDP -- the one value
+    // that must never reach the wire.
+    {
+        const int cols = getsysvar_scrCols();
+        const int rows = getsysvar_scrRows();
+        const int w = cols > 0 ? getsysvar_scrwidth() / cols : 0;
+        const int h = rows > 0 ? getsysvar_scrheight() / rows : 0;
+        scr->charW_ = (char) (w > 0 && w < 256 ? w : 8);
+        scr->charH_ = (char) (h > 0 && h < 256 ? h : 8);
+    }
     scr->cursor_ = cursor;
     scr->lastFname_[0] = 0;
     scr->lastPosW_ = 0;
@@ -803,7 +818,7 @@ void scr_scroll_h(screen* scr, int cols) {
     } else {
         scroll[3] = 1;   // window right -> content left
     }
-    scroll[4] = 8;       // one character cell
+    scroll[4] = scr->charW_;   // one character cell, in pixels
 
     define_viewport(0, scr->bottomY_ - 1, (char) (scr->cols_ - 1), scr->topY_);
     for (int i = 0; i < n; i++) {
@@ -839,13 +854,13 @@ void scr_put_at(screen* scr, char sx, char sy, char ch) {
 
 void scr_scroll_down(
         screen* scr, char topY, char bottomY, char* line, int sz, char ch) {
-    static const char down[] = {23, 7, 0, 2, 8};
+    const char down[] = {23, 7, 0, 2, scr->charH_};
     scroll_region(scr, topY, bottomY, down, sizeof(down), line, sz, ch);
 }
 
 void scr_scroll_up(
         screen* scr, char topY, char bottomY, char* line, int sz, char ch) {
-    static const char up[] = {23, 7, 0, 3, 8};
+    const char up[] = {23, 7, 0, 3, scr->charH_};
     scroll_region(scr, topY, bottomY, up, sizeof(up), line, sz, ch);
 }
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -40,6 +40,16 @@ typedef struct _screen {
     int cols_;
     char colors_;
 
+    // Size of one character cell in pixels, which is what VDU 23,7 scrolls by.
+    // Its movement byte has two meanings: 0 is "one character cell", anything
+    // else is a pixel count. Zero is the obvious choice and cannot be used --
+    // it only gained that meaning in Console8 VDP 2.5.0, and on the VDP 1.04
+    // this editor still supports it means no movement at all, which would stop
+    // the screen scrolling entirely. So a pixel count it is, and it has to be
+    // the real cell size rather than the 8 the system font happens to use.
+    char charW_;
+    char charH_;
+
     char currX_;
     char currY_;
 

--- a/test/stubs/agon/mos.h
+++ b/test/stubs/agon/mos.h
@@ -25,8 +25,11 @@ uint8_t* mos_sysvars(void);
 /* The screen MOS reports. 80x25 unless a test says otherwise -- the widest
  * real mode is 128 columns, which does not fit in a signed char. */
 void     stub_set_screen(int cols, int rows);
+void     stub_set_cell(int w, int h);
 
 uint8_t  getsysvar_keymods(void);
+uint16_t getsysvar_scrwidth(void);
+uint16_t getsysvar_scrheight(void);
 uint8_t  getsysvar_scrCols(void);
 uint8_t  getsysvar_scrRows(void);
 uint8_t  getsysvar_scrColours(void);

--- a/test/stubs/agon_stubs.c
+++ b/test/stubs/agon_stubs.c
@@ -184,6 +184,18 @@ static uint8_t stub_mods_now;
 void stub_set_keymods(int mods) { stub_mods_now = (uint8_t) mods; }
 
 uint8_t getsysvar_keymods(void)    { return stub_mods_now; }
+/* Pixel dimensions consistent with the 8x8 system font, so charW_/charH_ come
+ * out at 8 unless a test deliberately sets a different cell size. */
+static uint16_t stub_cellw = 8;
+static uint16_t stub_cellh = 8;
+
+void stub_set_cell(int w, int h) {
+    stub_cellw = (uint16_t) w;
+    stub_cellh = (uint16_t) h;
+}
+
+uint16_t getsysvar_scrwidth(void)  { return (uint16_t)(stub_cellw * stub_cols); }
+uint16_t getsysvar_scrheight(void) { return (uint16_t)(stub_cellh * stub_rows); }
 uint8_t getsysvar_scrCols(void)    { return stub_cols; }
 uint8_t getsysvar_scrRows(void)    { return stub_rows; }
 uint8_t getsysvar_scrColours(void) { return 16; }

--- a/test/test_scr_scroll.c
+++ b/test/test_scr_scroll.c
@@ -82,6 +82,11 @@ static screen mkscreen(void) {
     scr.topY_ = 1;
     scr.bottomY_ = 24;
     scr.tab_size_ = SCR_DEFAULT_TAB_SIZE;
+    /* What scr_init derives from the pixel dimensions for the stock 8x8 system
+     * font. A hand-built fixture that leaves these zero would emit a movement
+     * byte of 0, which on VDP 1.04 means no movement at all. */
+    scr.charW_ = 8;
+    scr.charH_ = 8;
     scr.currX_ = 0;
     scr.currY_ = 5;
 
@@ -116,6 +121,36 @@ int main(void) {
         const int rn = cap_read(got, sizeof(got));
         check("a scroll viewport stops before it", rn > 3 && got[3] == 78, 1);
         scr_destroy(&real);
+    }
+
+    /* The VDU 23,7 movement byte is a pixel count, and it has to be the real
+     * cell size rather than the 8 the system font happens to use. Movement 0
+     * would say "one character cell" and would be the obvious choice, but that
+     * meaning only arrived in Console8 VDP 2.5.0 -- on the VDP 1.04 this editor
+     * supports it means no movement, so 0 must never reach the wire. A 16-pixel
+     * font therefore has to scroll by 16. */
+    {
+        stub_set_cell(16, 16);
+        stub_set_screen(80, 25);
+        screen big;
+        scr_init(&big, 32);
+        check("cell height derived from the pixel dimensions", big.charH_, 16);
+        check("cell width derived from the pixel dimensions", big.charW_, 16);
+
+        cap_start();
+        scr_scroll_up(&big, 3, 20, line, 5, 'x');
+        const int bn = cap_read(got, sizeof(got));
+        check("vertical scroll moves by one cell, not a fixed 8",
+              bn > 9 && got[9] == 16, 1);
+
+        cap_start();
+        scr_scroll_h(&big, 1);
+        const int hn = cap_read(got, sizeof(got));
+        check("horizontal scroll moves by one cell too",
+              hn > 9 && got[9] == 16, 1);
+
+        scr_destroy(&big);
+        stub_set_cell(8, 8);
     }
 
     /* VDU 28,left,bottom,right,top  then  VDU 23,7,0,dir,8  then  VDU 26.


### PR DESCRIPTION
I had this on the open list as "VDU 23,7 movement should be 0, not 8 -- pixels
where characters were meant". That was wrong, and the reason is worth writing
down because it inverts the fix.

`VDU 23,7,extent,direction,movement`: a movement of 0 means one character cell,
anything else is a pixel count. So 0 is what the code appears to want. From
agon-docs:

> Support for a `movement` value of zero was added in Agon Console8 VDP 2.5.0.
> Before this version a `movement` value of zero would be interpreted as **no
> movement**.

AED's documented floor is VDP 1.04. Changing 8 to 0 would have stopped the
screen scrolling on the oldest firmware we support, and would have looked
correct in every test and on the emulator we develop against.

The literal 8 was therefore deliberate, not a bug: it is the pixel size of one
cell in the 8x8 system font. What it does get wrong is assuming that font. A
font loaded through the VDP font API before AED starts tears the text area on
every scroll.

So `scr_init` derives the cell size from the pixel dimensions MOS reports
alongside the column and row counts it is already trusted for, and the three
scroll sites use it. The derivation is guarded: a 0 from an unpopulated sysvar
falls back to 8, because 0 is the one value that must never reach the wire.

Tests set a 16-pixel cell and assert the movement byte follows it vertically and
horizontally. The hand-built fixture in `test_scr_scroll.c` needed `charW_`/
`charH_` set too -- it memsets the screen to zero, which without this emits
exactly the byte that breaks 1.04.

Mutations checked: reverting either scroll site to a literal 8 fails one
assertion; dropping the zero guard fails two.