### PR TITLE
Keep a file's line endings instead of rewriting them

### DIFF
--- a/src/text_buffer.c
+++ b/src/text_buffer.c
@@ -38,6 +38,7 @@ text_buffer* tb_init(text_buffer* tb, int mem_kb, const char* fname) {
     tb->x_ = 0;
     tb->fname_[0] = 0;
     tb->dirty_ = false;
+    tb->eol_ = TB_EOL_CRLF;
 
     if (fname != NULL && !tb_load(tb, fname)) {
         lb_destroy(&tb->lb_);
@@ -635,6 +636,7 @@ void tb_copy(text_buffer* dst, text_buffer* src) {
     dst->x_ = src->x_;
     dst->fname_[0] = 0;
     dst->dirty_ = false;
+    dst->eol_ = src->eol_;
 }
 
 // Char read.
@@ -720,21 +722,48 @@ static bool tb_read(char fh, text_buffer* tb, int sz) {
     //  Now update the line buffer. Tabs are kept as-is -- they are one byte in
     //  the document and the view decides how wide they render. Only line
     //  endings are normalised, since the line index assumes a two-byte CRLF.
+    // `added` counts the CRs put in front of a bare LF, `crlf` the breaks that
+    // already had one. Together they say what the file's endings were, which is
+    // what decides how it goes back out.
     int added = 0;
+    int crlf = 0;
     for (int i = 0; i < sz; i++) {
         lb_cinc(&tb->lb_);
         if (cb_peek(cb) == '\n') {
-            added += ensure_newline(&tb->cb_, &tb->lb_);
+            const int n = ensure_newline(&tb->cb_, &tb->lb_);
+            if (n == 0) {
+                crlf++;
+            }
+            added += n;
         }
         cb_next(cb, 1);
     }
 
     if (cb_peek(cb) == '\n') {
-        added += ensure_newline(&tb->cb_, &tb->lb_);
+        const int n = ensure_newline(&tb->cb_, &tb->lb_);
+        if (n == 0) {
+            crlf++;
+        }
+        added += n;
     }
 
     cb_prev(cb, sz+added);
-    tb->dirty_ = added != 0;
+
+    // A file whose breaks were all bare LFs is written back as bare LFs, so
+    // opening it and saving it leaves it byte for byte as it was. That is what
+    // lets it be clean on open: nothing the user did, and nothing a save would
+    // do, has changed it.
+    //
+    // A file with both kinds cannot have that. It goes back out as CRLF, which
+    // rewrites its LF-only lines -- a real change to the file, so it opens
+    // dirty and the exit prompt is telling the truth.
+    if (added > 0 && crlf == 0) {
+        tb->eol_ = TB_EOL_LF;
+        tb->dirty_ = false;
+    } else {
+        tb->eol_ = TB_EOL_CRLF;
+        tb->dirty_ = added != 0;
+    }
 
     // Now move the line buffer back to the first line.
     while (lb_up(&tb->lb_)) ;
@@ -795,6 +824,9 @@ void tb_clear(text_buffer* tb) {
     lb_clear(&tb->lb_);
     tb->x_ = 0;
     tb->dirty_ = false;
+    // An emptied document has no endings to preserve, so it takes the platform
+    // default rather than keeping the last file's.
+    tb->eol_ = TB_EOL_CRLF;
 }
 
 tb_result tb_open(text_buffer* tb, const char* fname, int sz) {
@@ -850,6 +882,63 @@ tb_result tb_open(text_buffer* tb, const char* fname, int sz) {
     return ok ? TB_OK : TB_NO_FILE;
 }
 
+// Writes the document with the CR of every CRLF dropped, so a file that came in
+// with bare LFs goes back out with them. Buffered because doing it a byte at a
+// time would be one MOS call per character.
+//
+// Only a CR that is immediately followed by an LF is dropped. A lone CR is text
+// as far as this editor is concerned -- an LF-only file can still contain one,
+// and it survives the round trip.
+typedef struct _lf_writer {
+    char fh;
+    int n;
+    char buf[256];
+} lf_writer;
+
+static void lfw_flush(lf_writer* w) {
+    if (w->n > 0) {
+        mos_fwrite(w->fh, w->buf, (unsigned) w->n);
+        w->n = 0;
+    }
+}
+
+static void lfw_put(lf_writer* w, char c) {
+    if (w->n == (int) sizeof(w->buf)) {
+        lfw_flush(w);
+    }
+    w->buf[w->n++] = c;
+}
+
+// The document is two segments with the gap between them, at wherever the cursor
+// happens to be. This walks them as one stream so that where the split fell is
+// not something the CR test has to care about.
+//
+// Cursor movement steps over a break two bytes at a time, so the gap is not
+// thought to be able to land between a CR and its LF -- a test that breaks only
+// that case fails nothing. The lookahead spans the segments anyway: it costs one
+// comparison, and the alternative is this staying correct only for as long as
+// that remains true of every edit path.
+static void tb_write_lf(char fh, const char* pre, int psz,
+                        const char* suf, int ssz) {
+    lf_writer w;
+    w.fh = fh;
+    w.n = 0;
+
+    const int total = psz + ssz;
+    for (int i = 0; i < total; i++) {
+        const char c = i < psz ? pre[i] : suf[i - psz];
+        if (c == '\r') {
+            const int j = i + 1;
+            const char nx = j < psz ? pre[j] : (j < total ? suf[j - psz] : 0);
+            if (nx == '\n') {
+                continue;
+            }
+        }
+        lfw_put(&w, c);
+    }
+    lfw_flush(&w);
+}
+
 bool tb_save(text_buffer* tb) {
     if (!tb_valid_file(tb)) {
         return false;
@@ -868,11 +957,16 @@ bool tb_save(text_buffer* tb) {
     int ssz = 0;
     tb_content(tb, &prefix, &psz, &suffix, &ssz);
 
-    if (prefix != NULL && psz > 0) {
-        mos_fwrite(fh, prefix, psz);
-    }
-    if (suffix != NULL && ssz > 0) {
-        mos_fwrite(fh, suffix, ssz);
+    if (tb->eol_ == TB_EOL_LF) {
+        tb_write_lf(fh, prefix, prefix != NULL ? psz : 0,
+                    suffix, suffix != NULL ? ssz : 0);
+    } else {
+        if (prefix != NULL && psz > 0) {
+            mos_fwrite(fh, prefix, psz);
+        }
+        if (suffix != NULL && ssz > 0) {
+            mos_fwrite(fh, suffix, ssz);
+        }
     }
 
     mos_fclose(fh);

--- a/src/text_buffer.h
+++ b/src/text_buffer.h
@@ -22,11 +22,20 @@
 #include "char_buffer.h"
 #include "line_buffer.h"
 
+// Line ending the document came in with, and the one it goes back out as. The
+// buffer itself is always CRLF -- every consumer of the line index subtracts 2
+// for a break -- so this is purely about what reaches the file.
+typedef enum _tb_eol_style {
+    TB_EOL_CRLF = 0,
+    TB_EOL_LF,
+} tb_eol_style;
+
 typedef struct _text_buffer {
     char_buffer cb_;
     line_buffer lb_;
     int x_;
     bool dirty_;
+    tb_eol_style eol_;
 
     char fname_[256];
 } text_buffer;

--- a/test/test_tb_load.c
+++ b/test/test_tb_load.c
@@ -32,6 +32,18 @@ static void check(const char* name, int got, int want) {
     }
 }
 
+static void check_bytes(const char* name, const char* got, int gotsz,
+                        const char* want) {
+    const int wantsz = (int) strlen(want);
+    if (gotsz == wantsz && memcmp(got, want, (size_t) wantsz) == 0) {
+        fprintf(stderr, "PASS  %-52s %d bytes\n", name, gotsz);
+    } else {
+        fprintf(stderr, "FAIL  %-52s got %d bytes, want %d\n",
+                name, gotsz, wantsz);
+        failures++;
+    }
+}
+
 int main(void) {
     stub_discard_output();
 
@@ -43,7 +55,13 @@ int main(void) {
     stub_file_set_content(small, (int) sizeof(small) - 1);
     check("small file loads", tb_init(&tb, 1, "small.txt") != NULL, 1);
     check("bare LFs became lines", tb_ymax(&tb), 4);
-    check("normalising marks the buffer dirty", tb_changed(&tb) ? 1 : 0, 1);
+    /* Re-baselined: this used to assert dirty. A file whose breaks are all bare
+     * LFs is now written back with bare LFs, so opening it and saving it leaves
+     * it byte for byte as it was -- there is nothing unsaved to warn about, and
+     * the exit prompt was firing on a file the user had not touched. Mixed
+     * endings still open dirty, asserted below, because those really are
+     * rewritten by a save. */
+    check("an LF-only file opens clean", tb_changed(&tb) ? 1 : 0, 0);
     tb_destroy(&tb);
 
     /* A file larger than the buffer must be refused, not read past the end of
@@ -109,6 +127,101 @@ int main(void) {
         tb_destroy(&tb);
     }
     free(lfs);
+
+    /* Line endings survive the round trip.
+     *
+     * The buffer is always CRLF -- the line index subtracts 2 for a break -- so
+     * what a file was written with has to be remembered separately and put back
+     * on the way out. Without that, opening a Unix file and saving it silently
+     * rewrote every line ending in it. */
+    {
+        stub_file_reset();
+        static const char unix_txt[] = "alpha\nbeta\ngamma\n";
+        stub_file_set_content(unix_txt, (int) sizeof(unix_txt) - 1);
+        text_buffer lf;
+        check("LF file loads", tb_init(&lf, 1, "unix.txt") != NULL, 1);
+        check("LF file is clean on open", tb_changed(&lf) ? 1 : 0, 0);
+
+        stub_file_reset();
+        check("LF file saves", tb_save(&lf) ? 1 : 0, 1);
+        check_bytes("LF file goes back out unchanged",
+                    stub_file_bytes(), stub_file_size(), unix_txt);
+        tb_destroy(&lf);
+    }
+
+    {
+        stub_file_reset();
+        static const char dos_txt[] = "alpha\r\nbeta\r\n";
+        stub_file_set_content(dos_txt, (int) sizeof(dos_txt) - 1);
+        text_buffer crlf;
+        check("CRLF file loads", tb_init(&crlf, 1, "dos.txt") != NULL, 1);
+        check("CRLF file is clean on open", tb_changed(&crlf) ? 1 : 0, 0);
+
+        stub_file_reset();
+        check("CRLF file saves", tb_save(&crlf) ? 1 : 0, 1);
+        check_bytes("CRLF file goes back out unchanged",
+                    stub_file_bytes(), stub_file_size(), dos_txt);
+        tb_destroy(&crlf);
+    }
+
+    /* Mixed endings cannot round trip: the document is one thing or the other
+     * on the way out. It goes out as CRLF, which rewrites the LF-only lines --
+     * a real change to the file, so this one is dirty from the moment it opens
+     * and the exit prompt is telling the truth. */
+    {
+        stub_file_reset();
+        static const char mixed_txt[] = "alpha\r\nbeta\ngamma\r\n";
+        stub_file_set_content(mixed_txt, (int) sizeof(mixed_txt) - 1);
+        text_buffer mixed;
+        check("mixed file loads", tb_init(&mixed, 1, "mixed.txt") != NULL, 1);
+        check("mixed endings open dirty", tb_changed(&mixed) ? 1 : 0, 1);
+
+        stub_file_reset();
+        check("mixed file saves", tb_save(&mixed) ? 1 : 0, 1);
+        check_bytes("mixed endings are normalised to CRLF",
+                    stub_file_bytes(), stub_file_size(),
+                    "alpha\r\nbeta\r\ngamma\r\n");
+        tb_destroy(&mixed);
+    }
+
+    /* The gap sits wherever the cursor is, so the document reaches the writer as
+     * two segments split at an arbitrary point. Saving with the cursor parked
+     * mid-document has to produce the same bytes as saving from the start. */
+    {
+        stub_file_reset();
+        static const char unix2[] = "alpha\nbeta\ngamma\ndelta\n";
+        stub_file_set_content(unix2, (int) sizeof(unix2) - 1);
+        text_buffer mid;
+        check("LF file loads for the split test",
+              tb_init(&mid, 1, "unix2.txt") != NULL, 1);
+
+        tb_pos p;
+        p.line = 3;
+        p.x = 2;
+        tb_seek(&mid, p);
+
+        stub_file_reset();
+        check("split-gap file saves", tb_save(&mid) ? 1 : 0, 1);
+        check_bytes("LF round trip holds with the gap mid-document",
+                    stub_file_bytes(), stub_file_size(), unix2);
+        tb_destroy(&mid);
+    }
+
+    /* A lone CR is text, not a line ending, and an LF-only file can contain
+     * one. Only the CR of a CRLF is dropped on the way out. */
+    {
+        stub_file_reset();
+        static const char cr_txt[] = "a\rb\nc\n";
+        stub_file_set_content(cr_txt, (int) sizeof(cr_txt) - 1);
+        text_buffer cr;
+        check("LF file with a lone CR loads", tb_init(&cr, 1, "cr.txt") != NULL, 1);
+
+        stub_file_reset();
+        check("lone-CR file saves", tb_save(&cr) ? 1 : 0, 1);
+        check_bytes("the lone CR survives the round trip",
+                    stub_file_bytes(), stub_file_size(), cr_txt);
+        tb_destroy(&cr);
+    }
 
     if (failures > 0) {
         fprintf(stderr, "\n%d test(s) failed\n", failures);


### PR DESCRIPTION
Opening a Unix file marked the document dirty before the user had typed
anything, so quitting asked to save work that did not exist.

The flag was not really wrong -- the buffer did differ from the file -- but the
reason it differed was AED's own doing, and hiding the flag would have hidden a
second, larger problem with it.

The buffer is always CRLF, because every consumer of the line index subtracts 2
for a break. A file of bare LFs was therefore rewritten on load, and saving it
converted every line ending in the file. Silently, and whether or not the user
had edited anything.

So the fix is to remember what the file had and put it back:

| file | written back as | on open |
|---|---|---|
| all CRLF, or no breaks | CRLF | clean |
| all bare LF | LF, byte for byte | clean |
| both kinds | CRLF | **dirty** |

The mixed case stays dirty on purpose. It cannot round trip, a save really does
rewrite its LF-only lines, and there the prompt is telling the truth instead of
crying wolf.

Only the CR of a CRLF is dropped on the way out -- a lone CR is text, and an
LF-only file can contain one.

Tests cover all three cases end to end, load through save, plus the lone CR and
a save with the gap parked mid-document. The existing `normalising marks the
buffer dirty` assertion pinned the old behaviour and is re-baselined with the
reason written down.

Mutations checked: always writing CRLF fails 2 assertions, treating mixed files
as LF fails 2, stripping every CR rather than only the one before an LF fails 1,
dropping the cross-segment lookahead fails 2.

One note on that last one. The writer looks ahead across the segment boundary,
and I had commented that a line break can straddle the gap. Breaking only that
exact case fails nothing, so I have not shown it can happen -- cursor movement
steps over a break two bytes at a time. The lookahead stays because it costs one
comparison and the alternative is code that is correct only while that remains
true of every edit path, but the comment now says that rather than implying the
case was observed.