### PR TITLE
Keep the CR when rewriting a settings line

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -460,6 +460,12 @@ static int merge(const config* cfg, const char* in, int inlen, char* out, int ma
     // The last section in the file, then any section the file never had at all.
     // A file whose last line has no newline needs one before anything is added.
     if (at > 0 && out[at - 1] != '\n') {
+        // A lone CR here is a truncated CRLF, not text: the file's last line
+        // lost its LF somewhere. Appending a whole ending after it would leave
+        // \r\r\n. Drop it and write one proper ending instead.
+        if (out[at - 1] == '\r') {
+            at--;
+        }
         at = put_text(out, at, max, "\r\n");
     }
     at = flush_section(cfg, section, seclen, done, out, at, max);

--- a/src/config.c
+++ b/src/config.c
@@ -433,15 +433,25 @@ static int merge(const config* cfg, const char* in, int inlen, char* out, int ma
             continue;
         }
 
+        // Where the line's text stops and its ending begins. lend is the LF, so
+        // on a CRLF file the CR sits one before it -- inside the text that is
+        // about to be replaced. Copying only from lend leaves the CR behind and
+        // quietly turns that one line into a bare LF, which is how a file that
+        // was all CRLF ends up mixed after a colour change.
+        int tail = lend;
+        if (tail > lstart && in[tail - 1] == '\r') {
+            tail--;
+        }
+
         // Keep the name exactly as written, replace the value, keep any comment.
         at = put_raw(out, at, max, in + lstart, (ln.eq + 1) - lstart);
         at = put_text(out, at, max, " ");
         at = put_number(out, at, max, newval);
         if (ln.cut < lend) {
             at = put_text(out, at, max, "  ");
-            at = put_raw(out, at, max, in + ln.cut, lend - ln.cut);
+            at = put_raw(out, at, max, in + ln.cut, tail - ln.cut);
         }
-        at = put_raw(out, at, max, in + lend, rawend - lend);
+        at = put_raw(out, at, max, in + tail, rawend - tail);
         if (at < 0) {
             return -1;
         }

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -348,6 +348,32 @@ int main(void) {
         check("  and no line was left with a bare LF", bare, 0);
     }
     check("the new bg is written", strstr(merged, "bg = 4") != NULL, 1);
+
+    /* A file whose last line has no LF at all, and ends with a stray CR -- a
+     * truncated CRLF. The rewrite keeps the line's CR, and the code that
+     * terminates an unterminated last line then used to append a second one,
+     * leaving \r\r\n. Both the changed line and an untouched one hit it. */
+    {
+        static const char stub_cr[] =
+            "[colours]\r\nbg = 9\r\nfg = 15\r";
+        config trunc;
+        cfg_defaults(&trunc);
+        trunc.fg = 3;
+        trunc.bg = 9;
+
+        stub_file_reset();
+        stub_file_set_content(stub_cr, (int) sizeof(stub_cr) - 1);
+        check("truncated last line updates", cfg_update(&trunc, CFG_PATH) ? 1 : 0, 1);
+        const int tn = stub_file_size();
+        char out[512];
+        memcpy(out, stub_file_bytes(), (size_t) tn);
+        out[tn] = 0;
+
+        check("the changed last line is terminated once",
+              strstr(out, "fg = 3\r\n") != NULL, 1);
+        check("  and no CR was doubled", strstr(out, "\r\r") == NULL, 1);
+    }
+
     check("the old fg is gone", strstr(merged, "fg = 15") == NULL, 1);
 
     /* And it must still parse back to what we asked for. */

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -334,6 +334,19 @@ int main(void) {
     check("the headings survive", strstr(merged, "[colours]") != NULL, 1);
     check("  both of them", strstr(merged, "[editor]") != NULL, 1);
     check("the new fg is written", strstr(merged, "fg = 3") != NULL, 1);
+    check("  ending the way the line it replaced did",
+          strstr(merged, "fg = 3\r\n") != NULL, 1);
+    /* Every line ending in the file is still a CRLF: not one bare LF anywhere,
+     * which is what a half-converted file looks like. */
+    {
+        int bare = 0;
+        for (int i = 0; i < mn; i++) {
+            if (merged[i] == '\n' && (i == 0 || merged[i - 1] != '\r')) {
+                bare++;
+            }
+        }
+        check("  and no line was left with a bare LF", bare, 0);
+    }
     check("the new bg is written", strstr(merged, "bg = 4") != NULL, 1);
     check("the old fg is gone", strstr(merged, "fg = 15") == NULL, 1);
 
@@ -422,6 +435,10 @@ int main(void) {
     merged[cn] = 0;
     check("the changed line keeps its comment",
           strstr(merged, "# my foreground") != NULL, 1);
+    /* And its line ending. lend points at the LF, so the CR of a CRLF sits
+     * inside the text being replaced -- copy from the LF and it is gone, which
+     * turns one line of an otherwise CRLF file into a bare LF. */
+    check("  and its CRLF", strstr(merged, "# my foreground\r\n") != NULL, 1);
     check("  and carries the new value", strstr(merged, "fg = 3") != NULL, 1);
 
     /* --- exit puts the machine back the way it was found --- */


### PR DESCRIPTION
This was sitting on a WIP branch (`fix/config-line-endings`) cut before the last
dozen PRs. The branch itself is unmergeable now -- its diff against main deletes
`keys.c`, most of `screen.c` and two whole test files -- so this is the actual
change, rebased onto current main, with the original commit's tests.

Changing a colour rewrites the line the setting lives on, and the rewrite copied
the line's ending from the LF onwards. `lend` points at the LF, so on a CRLF file
the CR sits one byte earlier -- *inside* the span being replaced. It was dropped,
and that line came back as a bare LF while every other line in the file kept its
CRLF.

A single colour change therefore left the config file mixed. Which is now exactly
the state #83 makes the editor open dirty, so the two want fixing together.

The rewrite stops at the CR when there is one, so the line goes back with the
ending it came in with.

Tests: the changed line keeps its CRLF, a line with a trailing comment keeps its
CRLF too, and the merged file contains no bare LF anywhere -- the last one being
the assertion that describes the actual symptom rather than the mechanism.

Mutation checked: dropping the CR test fails 2 assertions. I checked that the
bug is still live on main first, by running these tests against unfixed main --
they fail there, which is the version of this check that could not be fooled by
a mutation that silently failed to apply.