### PR TITLE
Record why AED keeps AgonDev's key handler

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -20,6 +20,41 @@
 
 #include <agon/keyboard.h>
 
+// On AgonDev's key handler, and why AED uses it anyway.
+//
+// MOS calls the key vector from inside its UART0 interrupt handler, with DE
+// holding the address of the four-byte VDP keyboard packet. An interrupt
+// handler is supposed to give every register back as it found it, and
+// <agon/keyboard.h>'s does not. Disassembled from libagon.a:
+//
+//     kbuf_event_handler:  push af / push bc / push hl
+//                          call kbuf_append
+//                          pop hl / pop bc / pop af / ret
+//
+//     kbuf_append:         ... ex de,hl / ld bc,4 / ldir
+//
+// DE is not saved, and the ex+ldir leaves it pointing four bytes into AED's own
+// ring buffer -- not merely advanced within MOS's packet, but somewhere else
+// entirely.
+//
+// It does not matter, and that is worth writing down because the obvious
+// reading says it should. MOS never reads DE after the vector returns. From
+// vdp_protocol.asm, vdp_protocol_KEY passes the packet address in DE, and on
+// the way back reloads every field absolutely:
+//
+//     LD A, (_vdp_protocol_data + 0)    ; ASCII
+//     LD A, (_vdp_protocol_data + 1)    ; modifiers
+//     ...then sets B and C itself before JP keyboard_handler
+//
+// keyboard_handler takes B and C and loads its own DE. So the clobber is a
+// contract violation with nothing downstream of it.
+//
+// A replacement vector in assembly was written and measured (branch
+// fix/own-key-vector). It is not merged: it puts hand-written code inside an
+// interrupt handler, where a mistake hangs the machine, to fix something no
+// caller can observe. Checked against MOS 3.x; the vector call has had this
+// shape since 2023.
+
 // Room for a burst without dropping any. The longest one AED can provoke is a
 // chord being released -- CTRL+SHIFT+RIGHT alone is six events, down and up for
 // three keys -- and holding a key repeats faster than a slow repaint returns


### PR DESCRIPTION
Closing out the parked `fix/own-key-vector` branch by writing down what it
found, rather than merging it.

The branch replaced `<agon/keyboard.h>`'s key handler with one in assembly,
because that handler does not preserve DE and MOS calls the key vector from
inside its UART0 interrupt handler with DE holding the packet address.

The premise checks out, and is worse than the branch claimed. Disassembled from
`libagon.a`:

```
kbuf_event_handler:  push af / push bc / push hl
                     call kbuf_append
                     pop hl / pop bc / pop af / ret

kbuf_append:         ... ex de,hl / ld bc,4 / ldir
```

DE is never saved, and the `ex de,hl` followed by `ldir` leaves it pointing four
bytes into AED's own ring buffer -- not "four bytes past MOS's packet", but a
different buffer entirely.

**It has no consequence.** MOS never reads DE after the vector returns. From
`agon-mos/src/vdp_protocol.asm`, `vdp_protocol_KEY` passes the address in DE and
then reloads every field absolutely on the way back:

```
LD A, (_vdp_protocol_data + 0)    ; ASCII
LD A, (_vdp_protocol_data + 1)    ; modifiers
LD A, (_vdp_protocol_data + 3)    ; key down
LD A, (_vdp_protocol_data + 2)    ; virtual keycode
JP keyboard_handler
```

B and C are set from those absolute loads, and `keyboard_handler` loads its own
DE before using it. So nothing downstream of the vector depends on the register
the handler destroys.

That makes the assembly replacement a change that puts hand-written code inside
an interrupt handler -- where a mistake hangs the machine, and where the host
test suite cannot reach -- to fix something no caller can observe. Not worth it.
The branch stays where it is; this records the finding so the question does not
get reopened from the disassembly alone, which is where I started and which
looks damning until you read the call site.

Checked against MOS 3.x. The comment in `vdp_protocol.asm` dates the vector call
to 2023, so older MOS versions are very likely the same shape, though I have not
diffed them.

Comment only, no behaviour change.