### PR TITLE
Measure the last-column pause, and record the VDU 5 decision

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -208,10 +208,22 @@ screen *scr_init(screen* scr, char cursor) {
     // it with VDU 8 failed -- there was nothing to cancel. The pause is
     // synchronous with the off-right transition, not deferred to the wrap.
     //
+    // Measured, not just read: test/probes/lastcol.c writes one character in a
+    // chosen column and counts key events beside it. On VDP 2.16.0, six taps
+    // with the chord held leave the counter blank until the keys come up when
+    // it writes this column, and reading 8 while they are still down when it
+    // writes the one before it. Two builds, one column apart.
+    //
     // It cannot be switched off. Paged mode does not gate it, VDP variable
-    // 0x1022 covers only the CTRL-alone branch, kbEnabled is never cleared,
-    // !textCursorActive() means VDU 5, and scrollProtect guards only the
-    // post-string newline.
+    // 0x1022 covers only the CTRL-alone branch, kbEnabled is never cleared, and
+    // scrollProtect guards only the post-string newline.
+    //
+    // One route does exist and is deliberately not taken. checkPagedMode opens
+    // with `if (!textCursorActive()) return;`, so text plotted at the graphics
+    // cursor -- VDU 5 -- never reaches the pause and could hold this column.
+    // It would cost graphics-coordinate positioning per write, in OS units that
+    // vary with the screen mode, for text that does not scroll with the rest.
+    // Declined 2026-09-05; the column is cheaper.
     //
     // cursorBehaviour.xHold (bit 5) would skip the block outright, and it is
     // old enough to rely on where the pause exists at all: the pause arrived in

--- a/test/probes/README.md
+++ b/test/probes/README.md
@@ -8,6 +8,16 @@ copy one into an AgonDev project with `NAME = <probe>` and run it on the device.
   this instead.
 
 See `.internal/docs/KEYBOARD.md` for what they were written to investigate.
+- `lastcol.c` — writes one character in a chosen column, over and over, and
+  counts key events beside it. Hold CTRL+SHIFT and tap an arrow: if the counter
+  keeps up, the writes are harmless; if it freezes until the keys are released,
+  the write is arming the VDP's CTRL+SHIFT pause. `COL_FROM_RIGHT` picks the
+  column, so building it twice gives two programs differing in one column.
+
+  Measured on VDP 2.16.0 / MOS 3.0.2, six taps with the chord held: writing the
+  last column of the screen freezes the counter and it catches up to 8 on
+  release; writing the column before it shows 8 while the keys are still down.
+  That is the evidence for the reserved column in `scr_init`.
 - `kbev.c` — prints every `agon/keyboard.h` event (ascii, kmod, vkey, up/down)
   as it arrives. This is the input path AED should use; the other two probes
   are from the superseded keyboard-map investigation.

--- a/test/probes/lastcol.c
+++ b/test/probes/lastcol.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <agon/keyboard.h>
+#include <agon/vdp.h>
+#include <agon/mos.h>
+
+/* Does writing the last column of the screen arm the VDP's CTRL+SHIFT pause?
+ *
+ * The claim under test is that it does, and that it is why AED reserves that
+ * column. The counter on row 0 advances once per key event. Hold CTRL+SHIFT and
+ * tap an arrow: if the counter keeps up, the writes are harmless; if it freezes
+ * until the keys are released, the write is arming the pause.
+ *
+ * Build twice, changing COL_FROM_RIGHT: 1 writes the last column of the screen,
+ * 2 writes the one before it -- which is what AED does now. Everything else is
+ * identical, so the two builds differ in one column.
+ *
+ * ESC alone quits. */
+#define COL_FROM_RIGHT 1
+
+int main(void) {
+    struct keyboard_event_t e;
+    static char msg[] = "hold CTRL+SHIFT and tap an arrow. ESC quits.";
+    static char count[] = "events=00000";
+
+    const int cols = getsysvar_scrCols();
+    const char col = (char) (cols - COL_FROM_RIGHT);
+
+    vdp_clear_screen();
+    vdp_cursor_tab(0, 0);
+    mos_puts(msg, sizeof(msg) - 1, 0);
+
+    kbuf_init(32);
+
+    unsigned n = 0;
+    for (;;) {
+        if (!kbuf_poll_event(&e)) {
+            continue;
+        }
+        if (!e.isdown) {
+            continue;
+        }
+        if (e.ascii == 27 && e.kmod == 0) {
+            break;
+        }
+
+        n++;
+        count[7]  = (char) ('0' + (n / 10000) % 10);
+        count[8]  = (char) ('0' + (n / 1000) % 10);
+        count[9]  = (char) ('0' + (n / 100) % 10);
+        count[10] = (char) ('0' + (n / 10) % 10);
+        count[11] = (char) ('0' + n % 10);
+
+        /* The write under test: one character in the column being probed, on a
+         * row of its own, repeated so a pause is unmistakable. */
+        for (int row = 4; row < 12; row++) {
+            vdp_cursor_tab(col, (char) row);
+            putchar('#');
+        }
+
+        vdp_cursor_tab(0, 2);
+        mos_puts(count, sizeof(count) - 1, 0);
+    }
+
+    kbuf_deinit();
+    vdp_cursor_tab(0, 14);
+
+    return 0;
+}


### PR DESCRIPTION
The reserved column in `scr_init` was argued from the VDP source: `plotString`
calls `checkPagedMode` when a printed character takes the cursor off the right
edge, and that stops output while CTRL+SHIFT are held. That is a reading of
someone else's code. This measures it.

`test/probes/lastcol.c` writes one character in a chosen column over and over and
counts key events beside it, so a pause shows up as a counter that stops.
`COL_FROM_RIGHT` picks the column, so two builds differ in one column and nothing
else. On VDP 2.16.0 / MOS 3.0.2, six taps of an arrow with the chord held:

| build | writes | counter while held | on release |
|---|---|---|---|
| `lastcol` | column W-1 | blank | `events=00008` |
| `nextcol` | column W-2 | `events=00008` | unchanged |

Two things this settles.

**The margin is not being kept for a theory.** The column really cannot hold a
printed character while that chord is held.

**But AED used to write it, and that was not a mistake.** Pre-#78 `scr_overwrite_line`
wrote `i < cols_` with `cols_ = 80`, column 79 included, and it worked -- the
CTRL+SHIFT pause only arrived in VDP 2.14.0. The conflict that column needed
handling for back then was the wrap/scroll on the bottom-right cell, which is a
different problem. Also worth correcting: the viewport off-by-one #78 "fixed" was
a red herring, since `setTextViewport` clamps with
`if (r.X2 >= canvasW) r.X2 = canvasW - 1` and `right=80` and `right=79` give the
same full-screen viewport.

**And the comment was wrong by omission.** It listed `!textCursorActive()` among
the things that do not disable the pause. It is not a dead end -- `checkPagedMode`
returns early when the text cursor is inactive, so text plotted at the graphics
cursor (VDU 5) never reaches it and could hold that column. Declined on cost:
graphics-coordinate positioning per write, in OS units that vary with the screen
mode, for text that does not scroll with the rest. The comment now says declined
rather than impossible, so the next reader does not rediscover it and assume it
was missed.

Probe and comments only; no behaviour change.