### PR TITLE
Add a probe that times SD reads, writes and seeks

### DIFF
--- a/test/probes/README.md
+++ b/test/probes/README.md
@@ -18,6 +18,22 @@ See `.internal/docs/KEYBOARD.md` for what they were written to investigate.
   last column of the screen freezes the counter and it catches up to 8 on
   release; writing the column before it shows 8 while the keys are still down.
   That is the evidence for the reserved column in `scr_init`.
+- `sdrate.c` — times bulk reads and writes, 1 KiB against 4 KiB operations, and
+  ascending against descending seeks. Written for the paging design in
+  `.internal/docs/PAGING.md`, which needs all three: throughput sets how long a
+  save takes, per-operation overhead sets the floor on the chunk size, and the
+  seek ratio says whether scrolling up costs more than scrolling down.
+
+  **Run it on hardware.** On the emulator with `--sdcard <path>` the host
+  filesystem serves the calls and MOS's FatFS does not appear to run at all:
+  reads and seeks both measure 0 cs, and two identical runs gave 673 and
+  1706 KiB/s for writes. The one thing that does come through is that the eZ80
+  side is not the bottleneck — with MOS and the C code in the loop throughout,
+  writes still exceeded 1.5 MiB/s. Whatever the real rate is, the card sets it.
+
+  A raw image (`--sdcard-img`) would make FatFS run for real and would answer
+  the seek and overhead questions, but still not throughput. It needs
+  `dosfstools` and `mtools`, neither of which is installed here.
 - `kbev.c` — prints every `agon/keyboard.h` event (ascii, kmod, vkey, up/down)
   as it arrives. This is the input path AED should use; the other two probes
   are from the superseded keyboard-map investigation.

--- a/test/probes/sdrate.c
+++ b/test/probes/sdrate.c
@@ -1,0 +1,135 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <agon/mos.h>
+#include <agon/vdp.h>
+
+/* How fast is the card, and where does the time actually go?
+ *
+ * Written for the paging design (.internal/docs/PAGING.md), which needs three
+ * numbers and only one of them is throughput:
+ *
+ *   1. bulk read and write rates, separately -- a paged save is a read pass and
+ *      a write pass, so they do not average.
+ *   2. the cost of a small operation against a large one. Total bytes moved per
+ *      unit of cursor travel does not depend on the chunk size, so smaller
+ *      chunks are smoother -- until per-operation overhead dominates. That
+ *      crossover is the floor on CHUNK.
+ *   3. seeking backwards against forwards. FatFS walks the cluster chain from
+ *      the start of the file unless a fast-seek table is set up, so scrolling
+ *      up may cost more than scrolling down. This is CPU work, so it is the one
+ *      figure the emulator reports faithfully.
+ *
+ * ON THE EMULATOR the first two measure MOS and FatFS, not a card: the host
+ * filesystem serves the reads and no SPI timing is emulated. Treat them as a
+ * lower bound. The third is a code path and transfers.
+ *
+ * sysvar_time is centiseconds, so every measurement is a loop long enough to
+ * be worth more than a tick or two. A result of 0 cs means "too fast to
+ * measure here", which is itself worth knowing.
+ */
+
+#define CHUNK   4096
+#define SMALL   1024
+#define TOTAL   (512L * 1024L)      /* bytes moved per bulk pass */
+#define SEEKS   64                  /* seek+read operations per direction */
+#define SEEKRD  512
+
+static char buf[CHUNK];
+static const char* PATH = "sdrate.tmp";
+
+static uint32_t cs(void) {
+    return getsysvar_time();
+}
+
+/* KiB/s from a byte count and a centisecond count, in integer maths. */
+static void report(const char* what, uint32_t bytes, uint32_t ticks) {
+    if (ticks == 0) {
+        printf("%-22s %6u cs   (too fast to measure)\r\n", what, 0u);
+
+        return;
+    }
+    const uint32_t kibps = (bytes / 1024u) * 100u / ticks;
+    printf("%-22s %6u cs  %6u KiB/s\r\n",
+           what, (unsigned) ticks, (unsigned) kibps);
+}
+
+static uint32_t write_pass(uint24_t chunk) {
+    uint8_t fh = mos_fopen(PATH, FA_WRITE | FA_CREATE_ALWAYS);
+    if (fh == 0) {
+        return 0;
+    }
+    const uint32_t t0 = cs();
+    for (uint32_t done = 0; done < TOTAL; done += chunk) {
+        mos_fwrite(fh, buf, chunk);
+    }
+    const uint32_t t1 = cs();
+    mos_fclose(fh);
+
+    return t1 - t0;
+}
+
+static uint32_t read_pass(uint24_t chunk) {
+    uint8_t fh = mos_fopen(PATH, FA_READ);
+    if (fh == 0) {
+        return 0;
+    }
+    const uint32_t t0 = cs();
+    for (uint32_t done = 0; done < TOTAL; done += chunk) {
+        mos_fread(fh, buf, chunk);
+    }
+    const uint32_t t1 = cs();
+    mos_fclose(fh);
+
+    return t1 - t0;
+}
+
+/* Seek to a spread of offsets and read a little at each. Ascending is what
+ * FatFS is built for; descending is what scrolling up will do. */
+static uint32_t seek_pass(bool ascending) {
+    uint8_t fh = mos_fopen(PATH, FA_READ);
+    if (fh == 0) {
+        return 0;
+    }
+    const uint32_t step = TOTAL / SEEKS;
+    const uint32_t t0 = cs();
+    for (int i = 0; i < SEEKS; i++) {
+        const uint32_t at = ascending
+            ? (uint32_t) i * step
+            : (uint32_t) (SEEKS - 1 - i) * step;
+        mos_flseek(fh, at);
+        mos_fread(fh, buf, SEEKRD);
+    }
+    const uint32_t t1 = cs();
+    mos_fclose(fh);
+
+    return t1 - t0;
+}
+
+int main(void) {
+    memset(buf, 'x', sizeof(buf));
+
+    vdp_clear_screen();
+    printf("SD throughput -- %u KiB per bulk pass\r\n\r\n",
+           (unsigned) (TOTAL / 1024));
+
+    report("write, 4K chunks",  TOTAL, write_pass(CHUNK));
+    report("read,  4K chunks",  TOTAL, read_pass(CHUNK));
+    report("write, 1K chunks",  TOTAL, write_pass(SMALL));
+    report("read,  1K chunks",  TOTAL, read_pass(SMALL));
+
+    printf("\r\n%d seek+read of %d bytes:\r\n", SEEKS, SEEKRD);
+    const uint32_t up = seek_pass(true);
+    const uint32_t down = seek_pass(false);
+    printf("  ascending offsets   %6u cs\r\n", (unsigned) up);
+    printf("  descending offsets  %6u cs\r\n", (unsigned) down);
+    if (up > 0) {
+        printf("  descending costs    %6u%% of ascending\r\n",
+               (unsigned) (down * 100u / up));
+    }
+
+    mos_del(PATH);
+    printf("\r\ndone.\r\n");
+
+    return 0;
+}


### PR DESCRIPTION
Written for the paging design in `.internal/docs/PAGING.md`, which needs three
numbers and only one of them is throughput:

- **bulk read and write, separately** — a paged save is a read pass and a write
  pass, so they do not average
- **1 KiB against 4 KiB operations** — total bytes moved per unit of cursor
  travel does not depend on chunk size, so smaller chunks are smoother until
  per-operation overhead dominates. That crossover is the floor on CHUNK.
- **ascending against descending seeks** — FatFS walks the cluster chain from the
  start of a file unless a fast-seek table is set up, so scrolling *up* may cost
  more than scrolling down

## Run it on hardware

On the emulator it answers almost nothing, and that is recorded in the probe and
the README so nobody repeats the exercise. With `--sdcard <path>` the host
filesystem serves the calls and MOS's FatFS does not appear to run at all:

```
write, 4K chunks           30 cs    1706 KiB/s
read,  4K chunks            0 cs   (too fast to measure)
write, 1K chunks           34 cs    1505 KiB/s
read,  1K chunks            0 cs   (too fast to measure)
64 seek+read of 512 bytes:
  ascending offsets        0 cs
  descending offsets       0 cs
```

Reads and seeks measure zero, and two identical runs gave 673 and 1706 KiB/s for
writes — a 2.5x spread that says the number is host filesystem behaviour, not
anything about a card.

The one useful result is a negative one: **the eZ80 side is not the bottleneck.**
With MOS and the C code in the loop throughout, writes still exceeded 1.5 MiB/s.
So whatever the real rate is, the card and SPI set it rather than software — and
the two estimates on the table, 1 MiB/s and 1 Mbit/s, differ by 8x and cannot be
told apart anywhere but on hardware. That 8x decides the chunk size and whether
the lazy-TAIL optimisation is optional.

A raw image (`--sdcard-img`) would make FatFS run for real and would answer the
seek and overhead questions, though still not throughput. It needs `dosfstools`
and `mtools`, neither of which is installed here.

Not part of the build; probe and README only, suite green.

**Merged without a Greptile review** — the account is at its 50-credit trial
limit, as with #92.