### PR TITLE
Document the font probe, and what a pass from it does not mean

### DIFF
--- a/test/probes/README.md
+++ b/test/probes/README.md
@@ -56,3 +56,24 @@ See `.internal/docs/KEYBOARD.md` for what they were written to investigate.
   installed here, but `SDL_VIDEODRIVER=dummy` works, and `log_word` smuggles
   numbers to the host through the VDP's debug log, which `--verbose` surfaces.
   See `.internal/docs/FONTS.md`.
+- `fonttest.c` — loads a font and shows the result, so a person can look at it.
+  Takes the path as an argument, so several can be compared without editing the
+  settings file:
+
+      fonttest /config/aed/unscii8x9.bin
+
+  Does what `scr_load_font` does and puts the workings on screen: whether the
+  VDP has the font API at all, the height the file implies, the measured ascent,
+  whether the mode packet came back, and the geometry afterwards. The sample
+  puts descenders directly above capitals, which is the comparison that matters
+  when choosing a height -- a 9- or 10-row font has a blank row between the two
+  and an 8-row font does not.
+
+  **A pass does not mean the font is correct.** The read-back asks the VDP to
+  match the screen against the font it is holding, so a font uploaded at the
+  wrong offset agrees with itself and reads back perfectly while the screen
+  shows nonsense. "renders" means glyphs are reaching the screen; whether they
+  are the *right* glyphs is what the sample text is for.
+
+  It reported everything healthy throughout the hunt for #109, and was right to:
+  the editor's blank screen was a stale object file, not the font path.

--- a/test/probes/fonttest.c
+++ b/test/probes/fonttest.c
@@ -21,6 +21,19 @@
  * the thing an 8x8 font cannot do anything about: with a 9-row font there is a
  * blank row between the two, and with an 8-row font there is not.
  *
+ * WHAT THE READ-BACK CANNOT TELL YOU. VDU 23,0,&83 asks the VDP to match what
+ * is on screen against the font it is currently holding. A font uploaded at the
+ * wrong offset therefore agrees with itself perfectly and reads back correct:
+ * every character comes back as the one that was written, while the screen
+ * shows something else entirely. So "renders" means the glyphs are reaching the
+ * screen, not that they are the right glyphs -- for that, look at the sample.
+ *
+ * This was written to find a blank text area in the editor and reported
+ * everything healthy, over and over, while the editor was unusable. It was
+ * right: the fault was a stale object file and nothing to do with fonts (#109).
+ * A tool that says the font path is fine is worth having for exactly that
+ * reason, but do not read more into a pass than it claims.
+ *
  * A key press between each stage, so there is time to look. The system font
  * goes back on the way out. */
 #define BUF_ID       0x0AED


### PR DESCRIPTION
`test/probes/fonttest.c` went in with #108 **by accident** — swept up by a
`git add -A` and unmentioned in that PR — so it arrived with no README entry and
nothing recorded about what it is for. This gives it both. No code changes; it
builds and runs unchanged.

## The caveat, which is the point of this

Its read-back uses `VDU 23,0,&83`, which asks the VDP to match what is on screen
against **the font it is currently holding**. A font uploaded at the wrong offset
therefore agrees with itself: every character reads back as the one that was
written, while the screen shows something else entirely.

So `renders` means the glyphs are reaching the screen — not that they are the
right glyphs. Only the sample text answers that, by eye.

That mattered. During #109 this probe reported `15 of 15` on both machines, every
time, while the editor was unusable, and I spent a long stretch treating that as
evidence the font was fine. It *was* fine — the fault was a stale object file —
but I could not have known that from a check which is structurally incapable of
detecting the failure it was being used to rule out.

## What it is good for

Comparing heights without editing the settings file:

```
fonttest /config/aed/unscii8x9.bin
fonttest /config/aed/unscii8x10low.bin
```

It does what `scr_load_font` does and puts the workings on screen: whether the
VDP has the font API, the height the file implies, the measured ascent, whether
the mode packet came back, and the resulting geometry. The sample puts descenders
directly above capitals, which is the comparison that decides a height — a 9- or
10-row font has a blank row between them and an 8-row font does not.